### PR TITLE
Resolved mismatch stubbings in CompareCoverageActionTest.java

### DIFF
--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -208,5 +208,7 @@ public class CompareCoverageActionTest {
         when(envVars.get(PrIdAndUrlUtils.GIT_PR_ID_ENV_PROPERTY)).thenReturn(prId);
         when(envVars.get(Utils.BUILD_URL_ENV_PROPERTY)).thenReturn(buildUrl);
         when(envVars.get(PrIdAndUrlUtils.GIT_URL_PROPERTY)).thenReturn(GIT_URL);
+        when(envVars.get("CHANGE_ID")).thenReturn(null);
+        when(envVars.get("CHANGE_URL")).thenReturn(null);
     }
 }


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `postCoverageStatusToPullRequestAsComment`, `postResultAsStatusCheck`, `postResultAsSuccessfulStatusCheck`, `postResultAsFailedStatusCheck`, `keepBuildGreenAndLogErrorIfExceptionDuringGitHubAccess`,  `postCoverageStatusToPullRequestAsCommentWithShieldIoIfPrivateJenkinsPublicGitHubTurnOn` and `postCoverageStatusToPullRequestAsCommentWithCustomJenkinsUrlIfConfigured`, 

* The `get` method for the `envVars` object:
i) is stubbed in the `prepareEnvVars` method
ii) during test execution the method is actually called with argument `"CHANGE_ID"`, but is not stubbed, resulting in a mismatch stubbing
iii) during test execution the method is actually called with argument `"CHANGE_URL"`, but is not stubbed, resulting in another mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.